### PR TITLE
Reload Cell Libraries warning on older KLayout versions

### DIFF
--- a/grain.xml
+++ b/grain.xml
@@ -3,7 +3,7 @@
  <name>LibraryManagerPlugin</name>
  <token/>
  <hidden>false</hidden>
- <version>0.25</version>
+ <version>0.26</version>
  <api-version/>
  <title>Library Manager Plugin</title>
  <doc>Library manager for hierarchical layouts</doc>

--- a/pymacros/library_manager_plugin.py
+++ b/pymacros/library_manager_plugin.py
@@ -659,6 +659,12 @@ class LibraryManagerPluginFactory(pya.PluginFactory):
     def on_reload_cell_libraries(self):
         if Debugging.DEBUG:
             debug("LibraryManagerPluginFactory.on_reload_cell_libraries")
+
+        if 'library_from_file' not in dir(pya.Library):  # added in KLayout 0.30.8 API
+            qmessagebox_critical('Error', 'Reload Cell Libraries failed', 
+                                 f"Reloading cell libraries is not possible prior to <pre>KLayout v0.30.8.</pre> "\
+                                 f"For now, please restart KLayout for any library cell changes to propagate.")
+            return
         
         try:        
             mw = pya.MainWindow.instance()

--- a/pymacros/library_map_changes.py
+++ b/pymacros/library_map_changes.py
@@ -46,7 +46,7 @@ class LibraryMapChanges:
     issues: LibraryMapIssues = field(default_factory=LibraryMapIssues)
 
     @classmethod
-    def compare(self, 
+    def compare(cls, 
                 base_folder: Path, 
                 old_config: LibraryMapConfig,
                 new_config: LibraryMapConfig) -> LibraryMapChanges:


### PR DESCRIPTION
As #53 was reverted, this is the portion with the warning.